### PR TITLE
feat: cordova 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,30 @@ app.initialize();
 
 ```
 
-### Screens
+## Screens
 
 ![Alt text](previews/first.png?raw=true "First load")
 ![Alt text](previews/search.png?raw=true "Search")
+
+## Android usage
+
+You will need to add some color definitions to your android project (if using cordova < 11, create a file named `colors.xml` inside `platforms/android/app/src/res/values`)
+```xml
+<color name="colorPrimary">#008577</color>
+<color name="colorPrimaryDark">#00574B</color>
+<color name="colorAccent">#D81B60</color>
+<color name="page_indicator">#C0202020</color>
+<color name="toolbar">#C0202020</color>
+```
+
+If you do not have a `colors.xml` file, this is a full example
+```xml
+<?xml version='1.0' encoding='utf-8'?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <color name="colorPrimary">#008577</color>
+    <color name="colorPrimaryDark">#00574B</color>
+    <color name="colorAccent">#D81B60</color>
+    <color name="page_indicator">#C0202020</color>
+    <color name="toolbar">#C0202020</color>
+</resources>
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net-kuama-plugins-pdfreader",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Cordova bridge for iOS PdfKit and android muPDF",
   "cordova": {
     "id": "net-kuama-plugins-pdfreader",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="net-kuama-plugins-pdfreader" version="0.0.5" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="net-kuama-plugins-pdfreader" version="0.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
     <name>PdfReader</name>
     <js-module name="PdfReader" src="www/PdfReader.js">
@@ -83,8 +83,6 @@
             <string name="text_not_found">Testo non trovato</string>
         </config-file>
 
-        <source-file src="src/android/res/values/colors.xml" target-dir="res/values"/>
-        <source-file src="src/android/res/values/dimens.xml" target-dir="res/values"/>
         <source-file src="src/android/res/values/styles.xml" target-dir="res/values"/>
 
     </platform>

--- a/src/android/res/values/colors.xml
+++ b/src/android/res/values/colors.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="colorPrimary">#008577</color>
-    <color name="colorPrimaryDark">#00574B</color>
-    <color name="colorAccent">#D81B60</color>
-    <color name="page_indicator">#C0202020</color>
-    <color name="toolbar">#C0202020</color>
-</resources>

--- a/src/android/res/values/dimens.xml
+++ b/src/android/res/values/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="fab_margin">16dp</dimen>
-</resources>


### PR DESCRIPTION
- Drop unused `dimens.xml` file
- Allow users to set their colors through `colors.xml` of the main app
- Update version to `0.1.0` since we're breaking internal auto-colors management.